### PR TITLE
Generate appropriate update recommendation when current version missing in datasource (#12618)

### DIFF
--- a/lib/workers/repository/process/lookup/current.ts
+++ b/lib/workers/repository/process/lookup/current.ts
@@ -42,5 +42,7 @@ export function getCurrentVersion(
     return versioning.minSatisfyingVersion(useVersions, currentValue);
   }
   // Use the highest version in the current range
-  return versioning.getSatisfyingVersion(useVersions, currentValue);
+  return (
+    versioning.getSatisfyingVersion(useVersions, currentValue) || lockedVersion
+  );
 }

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -1442,8 +1442,8 @@ describe('workers/repository/process/lookup/index', () => {
       // does not have our current version!
       expect(res.updates).toHaveLength(0);
     });
-    it('misses update with revoked current version 2', async () => {
-      config.currentValue = '~> 6.0.0';
+    it('detects update with extant current version 2', async () => {
+      config.currentValue = '^6.0.0';
       config.depName = 'some/action';
       config.lockedVersion = '6.0.0';
       config.datasource = datasourceGithubReleases.id;
@@ -1453,7 +1453,7 @@ describe('workers/repository/process/lookup/index', () => {
             version: '6.0.0',
           },
           {
-            version: '6.14.2',
+            version: '7.0.0',
           },
         ],
       });
@@ -1461,14 +1461,14 @@ describe('workers/repository/process/lookup/index', () => {
       expect(res.updates).toHaveLength(1);
     });
     it('misses update with revoked current version 2', async () => {
-      config.currentValue = '~> 6.0.0';
+      config.currentValue = '^6.0.0';
       config.depName = 'some/action';
       config.lockedVersion = '6.0.0';
       config.datasource = datasourceGithubReleases.id;
       githubReleases.getReleases.mockResolvedValueOnce({
         releases: [
           {
-            version: '6.14.2',
+            version: '7.0.0',
           },
         ],
       });

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -15,16 +15,20 @@ import { id as datasourceGithubTagsId } from '../../../../datasource/github-tags
 import { id as datasourceNpmId } from '../../../../datasource/npm';
 import { id as datasourcePackagistId } from '../../../../datasource/packagist';
 import { PypiDatasource } from '../../../../datasource/pypi';
+import * as datasourceRubygems from '../../../../datasource/rubygems';
+import { id as datasourceRubygemsId } from '../../../../datasource/rubygems';
 import { id as dockerVersioningId } from '../../../../versioning/docker';
 import { id as gitVersioningId } from '../../../../versioning/git';
 import { id as npmVersioningId } from '../../../../versioning/npm';
 import { id as pep440VersioningId } from '../../../../versioning/pep440';
 import { id as poetryVersioningId } from '../../../../versioning/poetry';
+import { id as rubyVersioningId } from '../../../../versioning/ruby';
 import type { LookupUpdateConfig } from './types';
 import * as lookup from '.';
 
 jest.mock('../../../../datasource/docker');
 jest.mock('../../../../datasource/github-releases');
+jest.mock('../../../../datasource/rubygems');
 
 const fixtureRoot = '../../../../config/npm';
 const qJson = {
@@ -39,7 +43,8 @@ const vueJson = loadJsonFixture('vue.json', fixtureRoot);
 const webpackJson = loadJsonFixture('webpack.json', fixtureRoot);
 
 const docker = mocked(datasourceDocker) as any;
-docker.defaultRegistryUrls = ['https://index.docker.io'];
+// docker.defaultRegistryUrls = ['https://index.docker.io'];
+const rubygems = mocked(datasourceRubygems) as any;
 const githubReleases = mocked(datasourceGithubReleases);
 
 Object.assign(githubReleases, { defaultRegistryUrls: ['https://github.com'] });
@@ -1398,6 +1403,57 @@ describe('workers/repository/process/lookup/index', () => {
       const res = await lookup.lookupUpdates(config);
       // FIXME: explicit assert condition
       expect(res).toMatchSnapshot();
+    });
+    it('detects update with extant current version', async () => {
+      config.currentValue = '~> 6.0.0';
+      config.datasource = datasourceRubygemsId;
+      config.depName = 'some-dep';
+      config.lockedVersion = '6.0.0';
+      config.versioning = rubyVersioningId;
+      rubygems.getReleases.mockResolvedValueOnce({
+        releases: [
+          {
+            version: '6.0.0',
+          },
+          {
+            version: '6.14.2',
+          },
+        ],
+      });
+      const res = await lookup.lookupUpdates(config);
+      expect(res.updates).toHaveLength(1);
+    });
+    it('misses update with revoked current version', async () => {
+      // FIXME: Should detect this update event if datasource does not have our
+      // current version.
+      config.currentValue = '~> 6.0.0';
+      config.datasource = datasourceRubygemsId;
+      config.depName = 'some-dep';
+      config.lockedVersion = '6.0.0';
+      config.versioning = rubyVersioningId;
+      rubygems.getReleases.mockResolvedValueOnce({
+        releases: [
+          {
+            version: '6.14.2',
+          },
+        ],
+      });
+      const res = await lookup.lookupUpdates(config);
+      expect(res.updates).toHaveLength(0);
+    });
+    it('misses update with revoked current version 2', async () => {
+      config.currentValue = '1.4.4';
+      config.depName = 'some/action';
+      config.datasource = datasourceGithubReleases.id;
+      githubReleases.getReleases.mockResolvedValueOnce({
+        releases: [
+          {
+            version: '2.0.0',
+          },
+        ],
+      });
+      // FIXME: explicit assert condition
+      expect((await lookup.lookupUpdates(config)).updates).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

When the current version of a dependency is missing from the data source, but a newer version of that  is available, Renovate was not recommending the appropriate update (#12618). This provides a fix and two new accompanying tests.

Since we are not super familiar with this code, please make sure this approach makes sense.

## Context:

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
